### PR TITLE
don't serve statements with content-disposition: attachment

### DIFF
--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -30,8 +30,6 @@
 
 import logging
 
-from .base import BaseHandler
-
 try:
     import tornado4.web as tornado_web
 except ImportError:

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -64,40 +64,27 @@ class TaskDescriptionHandler(ContestHandler):
 class TaskStatementViewHandler(FileHandler):
     """Shows the statement file of a task in the contest.
 
-    logic:
-    - /tasks/(taskname)/statements/(langcode)/(taskname).(langcode).pdf returns the PDF
-    - /tasks/(taskname)/statements/(langcode),
-    - /tasks/(taskname)/statements/(langcode)/literally/anything/ all redirect to the URL that returns the PDF
-
-    Why? Because the thing at the end of the path will be offered as the filename when downloading the thing
     """
     @tornado_web.authenticated
     @actual_phase_required(0, 3)
     @multi_contest
-    def get(self, task_name, suffix):
+    def get(self, task_name, lang_code):
         task = self.get_task(task_name)
         if task is None:
             raise tornado_web.HTTPError(404)
 
-        if "/" not in suffix:
-            lang_code = suffix
-            suffix = ""
-        else:
-            lang_code, suffix = suffix.split("/", 1)
-
         if lang_code not in task.statements:
             raise tornado_web.HTTPError(404)
-
-        canonical_filename = "%s.%s.pdf" % (task.name, lang_code)
-        if suffix != canonical_filename:
-            self.sql_session.close()
-            self.redirect(self.contest_url("tasks", task.name, "statements", lang_code, canonical_filename))
-            return
 
         statement = task.statements[lang_code].digest
         self.sql_session.close()
 
-        self.fetch(statement, "application/pdf", None)
+        if len(lang_code) > 0:
+            filename = "%s.%s.pdf" % (task.name, lang_code)
+        else:
+            filename = "%s.pdf" % task.name
+
+        self.fetch(statement, "application/pdf", filename=filename, disposition="inline")
 
 
 class TaskAttachmentViewHandler(FileHandler):

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -40,7 +40,7 @@ $(document).ready(update_solution_template);
 <div class="row statement one_statement">
     <div class="span9">
     {% for lang_code in task.statements %}
-        <a href="{{ contest_url("tasks", task.name, "statements", lang_code) }}" class="btn btn-large btn-success">{% trans %}Download task statement{% endtrans %}</a>
+        <a href="{{ contest_url("tasks", task.name, "statements", lang_code) }}" target="_blank" class="btn btn-large btn-success">{% trans %}Download task statement{% endtrans %}</a>
     {% endfor %}
     </div>
 </div>
@@ -54,7 +54,7 @@ $(document).ready(update_solution_template);
         </p>
     {% for statement in task.statements.values()|sort(attribute="language") %}
         {% if statement.language in task.primary_statements %}
-        <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" class="btn btn-large btn-success">
+        <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" target="_blank" class="btn btn-large btn-success">
             {% set language_name = statement.language|format_locale %}
             {% if statement.language != language_name %}
                 {% trans lang=language_name %}Statement in <b>{{ lang }}</b>{% endtrans %}
@@ -66,7 +66,7 @@ $(document).ready(update_solution_template);
     {% endfor %}
     {% for statement in task.statements.values()|sort(attribute="language") %}
         {% if statement.language in participation.user.preferred_languages and statement.language not in task.primary_statements %}
-        <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" class="btn btn-large">
+        <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" target="_blank" class="btn btn-large">
             {% set language_name = statement.language|format_locale %}
             {% if statement.language != language_name %}
                 {% trans lang=language_name %}Statement in <b>{{ lang }}</b>{% endtrans %}
@@ -82,7 +82,7 @@ $(document).ready(update_solution_template);
             <ul>
     {% for statement in task.statements.values()|sort(attribute="language") %}
                 <li>
-                    <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}">
+                    <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" target="_blank">
         {% set language_name = statement.language|format_locale %}
         {% if statement.language != language_name %}
             {% trans lang=language_name %}<b>{{ lang }}</b>{% endtrans %}

--- a/cms/server/file_middleware.py
+++ b/cms/server/file_middleware.py
@@ -45,6 +45,7 @@ class FileServerMiddleware:
 
     DIGEST_HEADER = "X-CMS-File-Digest"
     FILENAME_HEADER = "X-CMS-File-Filename"
+    DISPOSITION_HEADER = "X-CMS-File-Disposition"
 
     def __init__(self, file_cacher, app):
         """Create an instance.
@@ -83,6 +84,7 @@ class FileServerMiddleware:
 
         digest = original_response.headers.pop(self.DIGEST_HEADER)
         filename = original_response.headers.pop(self.FILENAME_HEADER, None)
+        disposition = original_response.headers.pop(self.DISPOSITION_HEADER, "attachment")
         mimetype = original_response.mimetype
 
         try:
@@ -101,7 +103,7 @@ class FileServerMiddleware:
         response.mimetype = mimetype
         if filename is not None:
             response.headers.add(
-                "Content-Disposition", "attachment", filename=filename)
+                "Content-Disposition", disposition, filename=filename)
         response.set_etag(digest)
         response.cache_control.no_cache = True
         response.cache_control.private = True

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -69,7 +69,7 @@ class FileHandlerMixin(RequestHandler):
 
     """
 
-    def fetch(self, digest, content_type, filename=None):
+    def fetch(self, digest, content_type, filename=None, disposition=None):
         """Serve the file with the given digest.
 
         This will just add the headers required to trigger
@@ -83,6 +83,8 @@ class FileHandlerMixin(RequestHandler):
         self.set_header(FileServerMiddleware.DIGEST_HEADER, digest)
         if filename is not None:
             self.set_header(FileServerMiddleware.FILENAME_HEADER, filename)
+        if disposition is not None:
+            self.set_header(FileServerMiddleware.DISPOSITION_HEADER, disposition)
         self.set_header("Content-Type", content_type)
         self.finish()
 

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -69,7 +69,7 @@ class FileHandlerMixin(RequestHandler):
 
     """
 
-    def fetch(self, digest, content_type, filename):
+    def fetch(self, digest, content_type, filename=None):
         """Serve the file with the given digest.
 
         This will just add the headers required to trigger
@@ -81,7 +81,8 @@ class FileHandlerMixin(RequestHandler):
 
         """
         self.set_header(FileServerMiddleware.DIGEST_HEADER, digest)
-        self.set_header(FileServerMiddleware.FILENAME_HEADER, filename)
+        if filename is not None:
+            self.set_header(FileServerMiddleware.FILENAME_HEADER, filename)
         self.set_header("Content-Type", content_type)
         self.finish()
 


### PR DESCRIPTION
Statements are now served without the Content-Disposition: attachment header: the browser will open them instead of offering to download.

All statement links have target="_blank", most browsers will open them in a new tab.